### PR TITLE
[Feat] 카카오 인가코드를 Service로 위임하고, 카카오 관련 토큰과 사용자 정보를 응답하는 controller 코드

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '4.0.1'
+    id 'org.springframework.boot' version '3.2.5'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -41,7 +41,7 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
 
     // DB
-    runtimeOnly 'com.mysql:mysql-connector-j:8.3.0'
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'
@@ -49,9 +49,10 @@ dependencies {
 
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // Swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/oauth/controller/KakaoAuthController.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/oauth/controller/KakaoAuthController.java
@@ -1,0 +1,32 @@
+package com.catchsolmind.cheongyeonbe.domain.oauth.controller;
+
+import com.catchsolmind.cheongyeonbe.domain.oauth.dto.response.KakaoLoginResponse;
+import com.catchsolmind.cheongyeonbe.domain.oauth.service.KakaoAuthService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/*
+ * FE가 준 인가코드를 받아서 Service로 위임
+ */
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/oauth/kakao")
+@Slf4j
+public class KakaoAuthController {
+    private final KakaoAuthService kakaoAuthService;
+
+    @PostMapping("/login")
+    public ResponseEntity<KakaoLoginResponse> login(
+            @RequestParam("code") String code
+    ) {
+        KakaoLoginResponse response = kakaoAuthService.login(code);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/oauth/dto/response/KakaoLoginResponse.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/oauth/dto/response/KakaoLoginResponse.java
@@ -1,0 +1,27 @@
+package com.catchsolmind.cheongyeonbe.domain.oauth.dto.response;
+
+import com.catchsolmind.cheongyeonbe.domain.user.entity.User;
+import lombok.Builder;
+
+@Builder
+public record KakaoLoginResponse(
+        String accessToken,
+        String refreshToken,
+        Long userId,
+        String nickname,
+        String profileImg
+) {
+    public static KakaoLoginResponse of(
+            User user,
+            String accessToken,
+            String refreshToken
+    ) {
+        return new KakaoLoginResponse(
+                accessToken,
+                refreshToken,
+                user.getUserId(),
+                user.getNickname(),
+                user.getProfileImg()
+        );
+    }
+}

--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/user/dto/UserDto.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/user/dto/UserDto.java
@@ -1,0 +1,10 @@
+package com.catchsolmind.cheongyeonbe.domain.user.dto;
+
+public record UserDto(
+        Long userId,
+
+        String nickname,
+
+        String profileImg
+) {
+}

--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/user/entity/AuthProvider.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/user/entity/AuthProvider.java
@@ -1,0 +1,5 @@
+package com.catchsolmind.cheongyeonbe.domain.user.entity;
+
+public enum AuthProvider {
+    KAKAO
+}

--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/user/entity/User.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/user/entity/User.java
@@ -3,7 +3,6 @@ package com.catchsolmind.cheongyeonbe.domain.user.entity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.security.AuthProvider;
 import java.time.LocalDateTime;
 
 @Entity

--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.catchsolmind.cheongyeonbe.domain.user.repository;
+
+import com.catchsolmind.cheongyeonbe.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface UserRepository extends JpaRepository<User, UUID> {
+
+}

--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/user/service/UserService.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/user/service/UserService.java
@@ -1,0 +1,8 @@
+package com.catchsolmind.cheongyeonbe.domain.user.service;
+
+import com.catchsolmind.cheongyeonbe.domain.oauth.dto.response.KakaoUserResponse;
+import com.catchsolmind.cheongyeonbe.domain.user.dto.UserDto;
+
+public interface UserService {
+    UserDto findOrCreateUser(KakaoUserResponse kakaoUser);
+}

--- a/src/main/java/com/catchsolmind/cheongyeonbe/global/config/KakaoOAuthProperties.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/global/config/KakaoOAuthProperties.java
@@ -1,0 +1,23 @@
+package com.catchsolmind.cheongyeonbe.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "kakao.oauth")
+public class KakaoOAuthProperties {
+
+    private String tokenUri;
+
+    private String clientId;
+
+    private String clientSecret;
+
+    private String redirectUri;
+
+    private String userInfoUri;
+}

--- a/src/main/java/com/catchsolmind/cheongyeonbe/global/config/RestClientConfig.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/global/config/RestClientConfig.java
@@ -1,0 +1,14 @@
+package com.catchsolmind.cheongyeonbe.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  config:
+    import: optional:file:.env[.properties]
+
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}
@@ -7,9 +10,17 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: create
     open-in-view: false
 
 springdoc:
   swagger-ui:
     path: /swagger-ui.html
+
+kakao:
+  oauth:
+    token-uri: https://kauth.kakao.com/oauth/token
+    client-id: ${KAKAO_REST_API_KEY}
+    client-secret: ${KAKAO_CLIENT_SECRET}
+    redirect-uri: ${KAKAO_REDIRECT_URI:http://localhost:8080}
+    user-info-uri: https://kapi.kakao.com/v2/user/me

--- a/src/test/java/com/catchsolmind/cheongyeonbe/domain/oauth/controller/KakaoAuthControllerTest.java
+++ b/src/test/java/com/catchsolmind/cheongyeonbe/domain/oauth/controller/KakaoAuthControllerTest.java
@@ -1,0 +1,54 @@
+package com.catchsolmind.cheongyeonbe.domain.oauth.controller;
+
+import com.catchsolmind.cheongyeonbe.domain.oauth.dto.response.KakaoLoginResponse;
+import com.catchsolmind.cheongyeonbe.domain.oauth.service.KakaoAuthService;
+import com.catchsolmind.cheongyeonbe.global.fixture.oauth.KakaoLoginResponseFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(KakaoAuthController.class)
+class KakaoAuthControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private KakaoAuthService kakaoAuthService;
+
+    @Test
+    @WithMockUser
+    @DisplayName("카카오 인가코드를 받아서 로그인 API를 호출한다.")
+    void GetTheAuthorizationCodeAndRequestTheToken() throws Exception {
+        // given
+        String authorizationCode = "kakao-auth-code";
+
+        KakaoLoginResponse response = KakaoLoginResponseFixture.valid();
+
+        Mockito.when(kakaoAuthService.login(anyString()))
+                .thenReturn(response);
+
+        // when & then
+        mockMvc.perform(
+                        post("/oauth/kakao/login")
+                                .with(csrf())
+                                .param("code", authorizationCode)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").value("access-token"))
+                .andExpect(jsonPath("$.refreshToken").value("refresh-token"))
+                .andExpect(jsonPath("$.userId").value(1L))
+                .andExpect(jsonPath("$.nickname").value("유저1"))
+                .andExpect(jsonPath("$.profileImg").value("profile-img-url"));
+    }
+}

--- a/src/test/java/com/catchsolmind/cheongyeonbe/global/fixture/oauth/KakaoLoginResponseFixture.java
+++ b/src/test/java/com/catchsolmind/cheongyeonbe/global/fixture/oauth/KakaoLoginResponseFixture.java
@@ -1,0 +1,16 @@
+package com.catchsolmind.cheongyeonbe.global.fixture.oauth;
+
+import com.catchsolmind.cheongyeonbe.domain.oauth.dto.response.KakaoLoginResponse;
+
+public class KakaoLoginResponseFixture {
+
+    public static KakaoLoginResponse valid() {
+        return KakaoLoginResponse.builder()
+                .accessToken("access-token")
+                .refreshToken("refresh-token")
+                .userId(1L)
+                .nickname("유저1")
+                .profileImg("profile-img-url")
+                .build();
+    }
+}


### PR DESCRIPTION
- 카카오 OAuth 로그인 기능 구현을 위한 기본 설정
- 카카오 인가코드를 Service로 위임하고, 카카오 관련 토큰과 사용자 정보를 응답하는 controller 코드 구현
- Closes #7 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
* Kakao OAuth를 통한 로그인 기능이 추가되었습니다.

## 개선사항
* Spring Boot 플러그인 및 주요 의존성이 업데이트되었습니다.
* MySQL 커넥터 및 OpenAPI UI 의존성 관리가 개선되었습니다.
* 테스트 환경 구성이 강화되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->