### PR TITLE
[Feat] 인가코드로 토큰을 요청한 후, 해당 토큰으로 카카오 사용자 조회 

### DIFF
--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/oauth/dto/response/KakaoTokenResponse.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/oauth/dto/response/KakaoTokenResponse.java
@@ -1,0 +1,24 @@
+package com.catchsolmind.cheongyeonbe.domain.oauth.dto.response;
+
+/*
+ * - 참고: https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api
+ * - 카카오 API 호출용 토큰 정보
+ * - 카카오 JSON 키와 필드명이 동일해야 함
+ */
+
+import lombok.Builder;
+
+@Builder
+public record KakaoTokenResponse(
+
+        String token_type,
+
+        String access_token,
+
+        Integer expires_in,
+
+        String refresh_token,
+
+        Integer refresh_token_expires_in
+) {
+}

--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/oauth/dto/response/KakaoUserResponse.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/oauth/dto/response/KakaoUserResponse.java
@@ -1,0 +1,26 @@
+package com.catchsolmind.cheongyeonbe.domain.oauth.dto.response;
+
+/*
+ * 카카오에서 제공받은 토큰으로 조회한 사용자 정보
+ * UserEntity 생성에 사용
+ */
+
+import lombok.Builder;
+
+@Builder
+public record KakaoUserResponse(
+        Long id, // providerId
+
+        KakaoAccount kakaoAccount
+) {
+    @Builder
+    public record KakaoAccount(
+            Profile profile
+    ) {
+        @Builder
+        public record Profile(
+                String nickname // User.nickname
+        ) {
+        }
+    }
+}

--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/oauth/dto/response/KakaoUserResponse.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/oauth/dto/response/KakaoUserResponse.java
@@ -5,12 +5,14 @@ package com.catchsolmind.cheongyeonbe.domain.oauth.dto.response;
  * UserEntity 생성에 사용
  */
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 
 @Builder
 public record KakaoUserResponse(
         Long id, // providerId
 
+        @JsonProperty("kakao-account")
         KakaoAccount kakaoAccount
 ) {
     @Builder

--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/oauth/service/KakaoAuthService.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/oauth/service/KakaoAuthService.java
@@ -1,0 +1,7 @@
+package com.catchsolmind.cheongyeonbe.domain.oauth.service;
+
+import com.catchsolmind.cheongyeonbe.domain.oauth.dto.response.KakaoLoginResponse;
+
+public interface KakaoAuthService {
+    KakaoLoginResponse login(String code);
+}

--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/oauth/service/basic/BasicKakaoAuthService.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/oauth/service/basic/BasicKakaoAuthService.java
@@ -1,0 +1,75 @@
+package com.catchsolmind.cheongyeonbe.domain.oauth.service.basic;
+
+import com.catchsolmind.cheongyeonbe.domain.oauth.dto.response.KakaoLoginResponse;
+import com.catchsolmind.cheongyeonbe.domain.oauth.dto.response.KakaoTokenResponse;
+import com.catchsolmind.cheongyeonbe.domain.oauth.dto.response.KakaoUserResponse;
+import com.catchsolmind.cheongyeonbe.domain.oauth.service.KakaoAuthService;
+import com.catchsolmind.cheongyeonbe.global.config.KakaoOAuthProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class BasicKakaoAuthService implements KakaoAuthService {
+    private final RestTemplate restTemplate; // TODO: RestClient로 리팩토링
+    private final KakaoOAuthProperties kakaoOAuthProperties;
+
+
+    @Override
+    public KakaoLoginResponse login(String code) {
+        // 인가코드로 카카오 토큰 요청
+        KakaoTokenResponse kakaoTokenResponse = requestToken(code);
+
+        // 카카오 사용자 정보 조회
+        KakaoUserResponse kakaoUserResponse = getKakaoUserInfo(kakaoTokenResponse.access_token());
+
+        // 사용자 조회 or 생성
+
+        // JWT 발급
+
+        return null;
+    }
+
+    KakaoUserResponse getKakaoUserInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        ResponseEntity<KakaoUserResponse> response =
+                restTemplate.exchange(
+                        kakaoOAuthProperties.getUserInfoUri(),
+                        HttpMethod.GET,
+                        request,
+                        KakaoUserResponse.class
+                );
+
+        return response.getBody();
+    }
+
+    KakaoTokenResponse requestToken(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code"); // 카카오 고정
+        body.add("client_id", kakaoOAuthProperties.getClientId());
+        body.add("redirect_uri", kakaoOAuthProperties.getRedirectUri());
+        body.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+
+        ResponseEntity<KakaoTokenResponse> response =
+                restTemplate.postForEntity(
+                        kakaoOAuthProperties.getTokenUri(),
+                        request,
+                        KakaoTokenResponse.class
+                );
+
+        return response.getBody();
+    }
+}

--- a/src/test/java/com/catchsolmind/cheongyeonbe/domain/oauth/service/basic/BasicKakaoAuthServiceTest.java
+++ b/src/test/java/com/catchsolmind/cheongyeonbe/domain/oauth/service/basic/BasicKakaoAuthServiceTest.java
@@ -1,0 +1,94 @@
+package com.catchsolmind.cheongyeonbe.domain.oauth.service.basic;
+
+import com.catchsolmind.cheongyeonbe.domain.oauth.dto.response.KakaoTokenResponse;
+import com.catchsolmind.cheongyeonbe.domain.oauth.dto.response.KakaoUserResponse;
+import com.catchsolmind.cheongyeonbe.global.config.KakaoOAuthProperties;
+import com.catchsolmind.cheongyeonbe.global.fixture.oauth.KakaoTokenResponseFixture;
+import com.catchsolmind.cheongyeonbe.global.fixture.oauth.KakaoUserResponseFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BasicKakaoAuthServiceTest {
+    @InjectMocks
+    BasicKakaoAuthService kakaoAuthService;
+
+    @Mock
+    private RestTemplate restTemplate;
+    @Mock
+    private KakaoOAuthProperties kakaoOAuthProperties;
+
+    @Test
+    @DisplayName("인가코드로 카카오 토큰을 요청한다.")
+    void tokenRequestWithAuthorizationCode() {
+        // given
+        String code = "kakao-auth-code";
+        KakaoTokenResponse response = KakaoTokenResponseFixture.valid();
+
+        when(kakaoOAuthProperties.getTokenUri()).thenReturn("https://kauth.kakao.com/oauth/token");
+        when(kakaoOAuthProperties.getClientId()).thenReturn("client-id");
+        when(kakaoOAuthProperties.getRedirectUri()).thenReturn("redirect-uri");
+
+        when(restTemplate.postForEntity(
+                anyString(), // url
+                any(HttpEntity.class), // request(요청 바디+헤더)
+                eq(KakaoTokenResponse.class) // responseType(응답을 매핑할 클래스)
+        )).thenReturn(ResponseEntity.ok(response));
+
+        // when
+        KakaoTokenResponse result = kakaoAuthService.requestToken(code);
+
+        // then
+        assertThat(result.token_type()).isEqualTo("bearer");
+        assertThat(result.access_token()).isEqualTo("access-token");
+        assertThat(result.expires_in()).isEqualTo(21599);
+        assertThat(result.refresh_token()).isEqualTo("refresh-token");
+        assertThat(result.refresh_token_expires_in()).isEqualTo(5183999);
+    }
+
+    @Test
+    @DisplayName("카카오 토큰으로 카카오 사용자 정보를 조회한다.")
+    void getKakaoUserInfoUsingKakaoAccessToken() {
+        // given
+        String accessToken = KakaoTokenResponseFixture.valid().access_token();
+        KakaoUserResponse response = KakaoUserResponseFixture.valid();
+
+        when(kakaoOAuthProperties.getUserInfoUri()).thenReturn("https://kapi.kakao.com/v2/user/me");
+        when(restTemplate.exchange(
+                anyString(),
+                eq(HttpMethod.GET),
+                any(HttpEntity.class),
+                eq(KakaoUserResponse.class)
+        )).thenReturn(ResponseEntity.ok(response));
+
+        // when
+        KakaoUserResponse result = kakaoAuthService.getKakaoUserInfo(accessToken);
+
+        // then
+        assertThat(result.id()).isEqualTo(1L);
+        assertThat(result.kakaoAccount().profile().nickname()).isEqualTo("유저1 닉네임");
+    }
+
+    @Test
+    @DisplayName("카카오 사용자가 우리 서비스에 있는지 확인하고 없으면 생성한다.")
+    void verifyKakaoUserAndCreateIfNotExist() {
+
+    }
+
+    @Test
+    @DisplayName("JWT를 발급한다.")
+    void generateJwt() {
+    }
+}

--- a/src/test/java/com/catchsolmind/cheongyeonbe/global/fixture/oauth/KakaoTokenResponseFixture.java
+++ b/src/test/java/com/catchsolmind/cheongyeonbe/global/fixture/oauth/KakaoTokenResponseFixture.java
@@ -1,0 +1,16 @@
+package com.catchsolmind.cheongyeonbe.global.fixture.oauth;
+
+import com.catchsolmind.cheongyeonbe.domain.oauth.dto.response.KakaoTokenResponse;
+
+public class KakaoTokenResponseFixture {
+
+    public static KakaoTokenResponse valid() {
+        return KakaoTokenResponse.builder()
+                .token_type("bearer")
+                .access_token("access-token")
+                .expires_in(21599)
+                .refresh_token("refresh-token")
+                .refresh_token_expires_in(5183999)
+                .build();
+    }
+}

--- a/src/test/java/com/catchsolmind/cheongyeonbe/global/fixture/oauth/KakaoUserResponseFixture.java
+++ b/src/test/java/com/catchsolmind/cheongyeonbe/global/fixture/oauth/KakaoUserResponseFixture.java
@@ -1,0 +1,17 @@
+package com.catchsolmind.cheongyeonbe.global.fixture.oauth;
+
+import com.catchsolmind.cheongyeonbe.domain.oauth.dto.response.KakaoUserResponse;
+
+public class KakaoUserResponseFixture {
+
+    public static KakaoUserResponse valid() {
+        return KakaoUserResponse.builder()
+                .id(1L)
+                .kakaoAccount(KakaoUserResponse.KakaoAccount.builder()
+                        .profile(KakaoUserResponse.KakaoAccount.Profile.builder()
+                                .nickname("유저1 닉네임")
+                                .build())
+                        .build())
+                .build();
+    }
+}


### PR DESCRIPTION
- 인가코드로 토큰을 요청한 후, 해당 토큰으로 카카오 사용자 조회하는 기능을 구현하였습니다.
- Test는 fixture 패턴을 활용하였습니다. 
- 응답 DTO를 포함합니다.
- Closes #24 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Kakao 소셜 로그인 연동(토큰 조회, 사용자 프로필 조회) 기능이 추가되었습니다.
  * 로그인 흐름에 필요한 인증 처리 및 사용자 연계/생성 흐름의 기반이 마련되었습니다.

* **테스트**
  * Kakao 인증 서비스에 대한 단위 테스트와 재사용 가능한 테스트 데이터(토큰/유저 응답) 픽스처가 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->