### PR TITLE
[Fix/146] [전체 할 일] 조회 시 협약서 상태를 응답하는 로직 추가

### DIFF
--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/group/controller/GroupTaskController.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/group/controller/GroupTaskController.java
@@ -46,7 +46,7 @@ public class GroupTaskController {
 
     @GetMapping
     @Operation(summary = "전체 할일 목록 조회",
-            description = "AgreementStatus -  DRAFT(초안), CONFIRMED(확정)")
+            description = "AgreementStatus -  NONE(협약서 없음), DRAFT(초안), CONFIRMED(확정)")
     public GroupTaskListResponse getGroupTasks(
             @RequestParam Long groupId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,

--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/group/controller/GroupTaskController.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/group/controller/GroupTaskController.java
@@ -45,7 +45,8 @@ public class GroupTaskController {
     }
 
     @GetMapping
-    @Operation(summary = "전체 할일 목록 조회")
+    @Operation(summary = "전체 할일 목록 조회",
+            description = "AgreementStatus -  DRAFT(초안), CONFIRMED(확정)")
     public GroupTaskListResponse getGroupTasks(
             @RequestParam Long groupId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,

--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/group/dto/response/GroupTaskListResponse.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/group/dto/response/GroupTaskListResponse.java
@@ -15,6 +15,7 @@ public class GroupTaskListResponse {
 
     @JsonProperty("isSoloGroup")
     private boolean soloGroup;
+    private String agreementStatus;
     private LocalDate weekStart;
     private LocalDate weekEnd;
     private List<LocalDate> weekDates;

--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/group/dto/response/GroupTaskListResponse.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/group/dto/response/GroupTaskListResponse.java
@@ -14,7 +14,7 @@ import java.util.List;
 public class GroupTaskListResponse {
 
     @JsonProperty("isSoloGroup")
-    private boolean isSoloGroup;
+    private boolean soloGroup;
     private LocalDate weekStart;
     private LocalDate weekEnd;
     private List<LocalDate> weekDates;

--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/group/service/GroupTaskQueryService.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/group/service/GroupTaskQueryService.java
@@ -68,7 +68,7 @@ public class GroupTaskQueryService {
                 .collect(Collectors.toList());
 
         return GroupTaskListResponse.builder()
-                .isSoloGroup(isSoloGroup)
+                .soloGroup(isSoloGroup)
                 .weekStart(weekStart)
                 .weekEnd(weekEnd)
                 .weekDates(weekDates)

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -488,3 +488,7 @@ VALUES (100, '청연이의 우리 집', 5, NOW(), NOW());
 INSERT
 IGNORE INTO housework_test (user_id, result_type, created_at)
 VALUES (5, 'PERFECTIONIST', NOW());
+
+INSERT
+IGNORE INTO group_member (group_member_id, group_id, user_id, role, status, joined_at, agreed_at)
+VALUES (5, 100, 5, 'OWNER', 'AGREED', NOW(), NOW());


### PR DESCRIPTION
- Closes #146 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 그룹 할일 목록 조회 응답에 계약 상태(예: NONE, DRAFT, CONFIRMED) 필드 추가
  * 응답 내 그룹 유형 표시 필드 이름이 변경되어 클라이언트에서 해당 필드명 확인 필요

* **문서화**
  * 전체 할일 목록 조회 API 설명에 계약 상태 값 설명 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->