### PR TITLE
[Fix/148] 매니저 호출 정보 조회

### DIFF
--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/eraser/dto/response/ManagerCallResponse.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/eraser/dto/response/ManagerCallResponse.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 @Schema(description = "매니저 호출(예약) 정보")
 public record ManagerCallResponse(
         @Schema(description = "예약 ID")
-        Long reservationId,
+        Long reservationItemId,
 
         @Schema(description = "서비스명 (예: 주방 청소)")
         String serviceName,

--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/eraser/dto/response/ManagerCallResponse.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/eraser/dto/response/ManagerCallResponse.java
@@ -1,0 +1,21 @@
+package com.catchsolmind.cheongyeonbe.domain.eraser.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "매니저 호출(예약) 정보")
+public record ManagerCallResponse(
+        @Schema(description = "예약 ID")
+        Long reservationId,
+
+        @Schema(description = "서비스명 (예: 주방 청소)")
+        String serviceName,
+
+        @Schema(description = "방문 시간 (예: 14:00)")
+        String visitTime,
+
+        @Schema(description = "얻을 포인트")
+        Integer point
+) {
+}

--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/eraser/entity/ReservationItem.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/eraser/entity/ReservationItem.java
@@ -35,7 +35,8 @@ public class ReservationItem {
     private Integer price; // 예약 당시 가격 (스냅샷)
 
     @Column(name = "reward_point", nullable = false)
-    private Integer rewardPoint;
+    @Builder.Default
+    private Integer rewardPoint = 0;
 
     @Column(name = "visit_date", nullable = false)
     private LocalDate visitDate;

--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/eraser/entity/ReservationItem.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/eraser/entity/ReservationItem.java
@@ -34,6 +34,9 @@ public class ReservationItem {
     @Column(name = "price_at_reservation", nullable = false)
     private Integer price; // 예약 당시 가격 (스냅샷)
 
+    @Column(name = "reward_point", nullable = false)
+    private Integer rewardPoint;
+
     @Column(name = "visit_date", nullable = false)
     private LocalDate visitDate;
 

--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/eraser/repository/ReservationItemRepository.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/eraser/repository/ReservationItemRepository.java
@@ -1,0 +1,27 @@
+package com.catchsolmind.cheongyeonbe.domain.eraser.repository;
+
+import com.catchsolmind.cheongyeonbe.domain.eraser.entity.ReservationItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface ReservationItemRepository extends JpaRepository<ReservationItem, Long> {
+
+    // 그룹 ID와 날짜(VisitDate)로 예약 아이템 조회
+    // ReservationItem -> Reservation -> User -> GroupMember -> Group 순으로 연결하여 조회
+    @Query("SELECT ri FROM ReservationItem ri " +
+            "JOIN FETCH ri.reservation r " +
+            "JOIN FETCH r.user u " +
+            "WHERE u.userId IN (" +
+            "   SELECT gm.user.userId FROM GroupMember gm WHERE gm.group.groupId = :groupId" +
+            ") " +
+            "AND ri.visitDate = :date " +
+            "ORDER BY ri.visitTime ASC")
+    List<ReservationItem> findByGroupIdAndDate(
+            @Param("groupId") Long groupId,
+            @Param("date") LocalDate date
+    );
+}

--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/eraser/repository/ReservationItemRepository.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/eraser/repository/ReservationItemRepository.java
@@ -16,8 +16,7 @@ public interface ReservationItemRepository extends JpaRepository<ReservationItem
             "JOIN FETCH ri.reservation r " +
             "JOIN FETCH r.user u " +
             "WHERE u.userId IN (" +
-            "   SELECT gm.user.userId FROM GroupMember gm WHERE gm.group.groupId = :groupId" +
-            ") " +
+            "SELECT gm.user.userId FROM GroupMember gm WHERE gm.group.groupId = :groupId AND gm.status <> 'LEFT') " +
             "AND ri.visitDate = :date " +
             "ORDER BY ri.visitTime ASC")
     List<ReservationItem> findByGroupIdAndDate(

--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/eraser/service/EraserService.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/eraser/service/EraserService.java
@@ -2,12 +2,14 @@ package com.catchsolmind.cheongyeonbe.domain.eraser.service;
 
 import com.catchsolmind.cheongyeonbe.domain.eraser.dto.request.ReservationRequest;
 import com.catchsolmind.cheongyeonbe.domain.eraser.dto.response.EraserTaskOptionsResponse;
+import com.catchsolmind.cheongyeonbe.domain.eraser.dto.response.ManagerCallResponse;
 import com.catchsolmind.cheongyeonbe.domain.eraser.dto.response.PaymentInfoResponse;
 import com.catchsolmind.cheongyeonbe.domain.eraser.dto.response.RecommendationResponse;
 import com.catchsolmind.cheongyeonbe.domain.eraser.entity.Reservation;
 import com.catchsolmind.cheongyeonbe.domain.eraser.entity.ReservationItem;
 import com.catchsolmind.cheongyeonbe.domain.eraser.entity.SuggestionTask;
 import com.catchsolmind.cheongyeonbe.domain.eraser.entity.SuggestionTaskOption;
+import com.catchsolmind.cheongyeonbe.domain.eraser.repository.ReservationItemRepository;
 import com.catchsolmind.cheongyeonbe.domain.eraser.repository.ReservationRepository;
 import com.catchsolmind.cheongyeonbe.domain.eraser.repository.SuggestionTaskOptionRepository;
 import com.catchsolmind.cheongyeonbe.domain.eraser.repository.SuggestionTaskRepository;
@@ -53,6 +55,7 @@ public class EraserService {
     private final SuggestionTaskOptionRepository suggestionTaskOptionRepository;
     private final ReservationRepository reservationRepository;
     private final PointTransactionRepository pointTransactionRepository;
+    private final ReservationItemRepository reservationItemRepository;
 
     private final S3Properties s3Properties;
 
@@ -295,6 +298,7 @@ public class EraserService {
                     .taskTitle(option.getSuggestionTask().getTitle())
                     .optionCount(option.getCount())
                     .price(option.getPrice())
+                    .rewardPoint(option.getSuggestionTask().getRewardPoint())
                     .visitDate(itemReq.visitDate())
                     .visitTime(itemReq.visitTime())
                     .build();
@@ -336,6 +340,20 @@ public class EraserService {
         Reservation savedReservation = reservationRepository.save(reservation);
 
         return savedReservation.getReservationId();
+    }
+
+    // 특정 그룹, 특정 날짜의 매니저 호출 목록 조회
+    public List<ManagerCallResponse> getManagerCalls(Long groupId, LocalDate date) {
+        List<ReservationItem> items = reservationItemRepository.findByGroupIdAndDate(groupId, date);
+
+        return items.stream()
+                .map(item -> ManagerCallResponse.builder()
+                        .reservationId(item.getReservationItemId())
+                        .serviceName(item.getTaskTitle())
+                        .visitTime(item.getVisitTime())
+                        .point(item.getRewardPoint())
+                        .build())
+                .collect(Collectors.toList());
     }
 
     // 헬퍼 메서드

--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/eraser/service/EraserService.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/eraser/service/EraserService.java
@@ -348,7 +348,7 @@ public class EraserService {
 
         return items.stream()
                 .map(item -> ManagerCallResponse.builder()
-                        .reservationId(item.getReservationItemId())
+                        .reservationItemId(item.getReservationItemId())
                         .serviceName(item.getTaskTitle())
                         .visitTime(item.getVisitTime())
                         .point(item.getRewardPoint())

--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/group/dto/response/GroupTaskListResponse.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/group/dto/response/GroupTaskListResponse.java
@@ -1,5 +1,6 @@
 package com.catchsolmind.cheongyeonbe.domain.group.dto.response;
 
+import com.catchsolmind.cheongyeonbe.domain.eraser.dto.response.ManagerCallResponse;
 import com.catchsolmind.cheongyeonbe.global.enums.TaskCategory;
 import com.catchsolmind.cheongyeonbe.global.enums.TaskStatus;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -21,6 +22,7 @@ public class GroupTaskListResponse {
     private List<LocalDate> weekDates;
     private LocalDate selectedDate;
     private List<GroupTaskItemDto> items;
+    private List<ManagerCallResponse> managerCall;
 
     @Getter
     @Builder

--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/group/repository/GroupMemberRepository.java
@@ -28,7 +28,7 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
     // 그룹 전체 멤버 목록
     List<GroupMember> findByGroup_GroupId(Long groupId);
 
-    @Query("SELECT gm.group FROM GroupMember gm WHERE gm.user.userId = :userId AND gm.status = 'JOINED'")
+    @Query("SELECT gm.group FROM GroupMember gm WHERE gm.user.userId = :userId AND gm.status = 'AGREED'")
     Optional<Group> findGroupByUserId(@Param("userId") Long userId);
 
     // 특정 상태인 내 정보 찾기 (피드백 작성 가능한지 보기 위해)

--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/group/service/GroupTaskQueryService.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/group/service/GroupTaskQueryService.java
@@ -2,6 +2,8 @@ package com.catchsolmind.cheongyeonbe.domain.group.service;
 
 import com.catchsolmind.cheongyeonbe.domain.agreement.entity.Agreement;
 import com.catchsolmind.cheongyeonbe.domain.agreement.repository.AgreementRepository;
+import com.catchsolmind.cheongyeonbe.domain.eraser.dto.response.ManagerCallResponse;
+import com.catchsolmind.cheongyeonbe.domain.eraser.service.EraserService;
 import com.catchsolmind.cheongyeonbe.domain.group.dto.response.GroupTaskCalendarResponse;
 import com.catchsolmind.cheongyeonbe.domain.group.dto.response.GroupTaskDetailResponse;
 import com.catchsolmind.cheongyeonbe.domain.group.dto.response.GroupTaskListResponse;
@@ -32,6 +34,7 @@ public class GroupTaskQueryService {
     private final TaskTakeoverRepository takeoverRepository;
     private final GroupMemberRepository groupMemberRepository;
     private final AgreementRepository agreementRepository;
+    private final EraserService eraserService;
 
     public GroupTaskListResponse getGroupTasks(Long groupId, LocalDate selectedDate) {
         long memberCount = groupMemberRepository.countByGroup_GroupIdAndStatus(groupId, MemberStatus.JOINED);
@@ -81,6 +84,8 @@ public class GroupTaskQueryService {
                 })
                 .collect(Collectors.toList());
 
+        List<ManagerCallResponse> managerCalls = eraserService.getManagerCalls(groupId, selectedDate);
+
         return GroupTaskListResponse.builder()
                 .soloGroup(isSoloGroup)
                 .agreementStatus(agreementStatus)
@@ -89,6 +94,7 @@ public class GroupTaskQueryService {
                 .weekDates(weekDates)
                 .selectedDate(selectedDate)
                 .items(items)
+                .managerCall(managerCalls)
                 .build();
     }
 

--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/task/dto/response/MyTaskListResponse.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/task/dto/response/MyTaskListResponse.java
@@ -1,5 +1,6 @@
 package com.catchsolmind.cheongyeonbe.domain.task.dto.response;
 
+import com.catchsolmind.cheongyeonbe.domain.eraser.dto.response.ManagerCallResponse;
 import com.catchsolmind.cheongyeonbe.domain.task.dto.data.MyTaskItemDto;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,4 +17,6 @@ public class MyTaskListResponse {
 
     private LocalDate selectedDate;
     private List<MyTaskItemDto> items;
+
+    private List<ManagerCallResponse> managerCall;
 }

--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/task/service/MyTaskQueryService.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/task/service/MyTaskQueryService.java
@@ -1,5 +1,7 @@
 package com.catchsolmind.cheongyeonbe.domain.task.service;
 
+import com.catchsolmind.cheongyeonbe.domain.eraser.dto.response.ManagerCallResponse;
+import com.catchsolmind.cheongyeonbe.domain.eraser.service.EraserService;
 import com.catchsolmind.cheongyeonbe.domain.group.entity.GroupMember;
 import com.catchsolmind.cheongyeonbe.domain.task.dto.data.MyTaskItemDto;
 import com.catchsolmind.cheongyeonbe.domain.task.dto.response.MyTaskCalendarResponse;
@@ -28,6 +30,7 @@ public class MyTaskQueryService {
 
     private final TaskOccurrenceRepository occurrenceRepository;
     private final TaskTakeoverRepository takeoverRepository;
+    private final EraserService eraserService;
 
     public MyTaskListResponse getMyTasks(GroupMember member, LocalDate selectedDate) {
         LocalDate weekStart = selectedDate.with(DayOfWeek.MONDAY);
@@ -59,12 +62,16 @@ public class MyTaskQueryService {
                 })
                 .collect(Collectors.toList());
 
+        Long groupId = member.getGroup().getGroupId();
+        List<ManagerCallResponse> managerCalls = eraserService.getManagerCalls(groupId, selectedDate);
+
         return MyTaskListResponse.builder()
                 .weekStart(weekStart)
                 .weekEnd(weekEnd)
                 .weekDates(weekDates)
                 .selectedDate(selectedDate)
                 .items(items)
+                .managerCall(managerCalls)
                 .build();
     }
 


### PR DESCRIPTION
- Closes #148 
- [내 할 일]과 [전체 할 일] 클릭 시 매니저 호출 정보를 준다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 그룹/내 작업 목록에 관리자 호출(매니저 콜) 정보 추가
  * 예약에 리워드 포인트 저장 및 표시 기능 추가

* **버그 수정**
  * 그룹 멤버 조회 시 상태 필터링을 보다 엄격하게 개선 (정확한 멤버십 반영)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->