### PR TITLE
[Feat/154] 매니저 관련 imgUrl 같이 response하도록 수정

### DIFF
--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/eraser/dto/response/ManagerCallResponse.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/eraser/dto/response/ManagerCallResponse.java
@@ -9,6 +9,9 @@ public record ManagerCallResponse(
         @Schema(description = "예약 ID")
         Long reservationItemId,
 
+        @Schema(description = "매니저 프로필 이미지 url")
+        String imgUrl,
+
         @Schema(description = "서비스명 (예: 주방 청소)")
         String serviceName,
 

--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/eraser/service/EraserService.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/eraser/service/EraserService.java
@@ -29,6 +29,7 @@ import com.catchsolmind.cheongyeonbe.global.enums.TaskStatus;
 import com.catchsolmind.cheongyeonbe.global.enums.TransactionType;
 import com.catchsolmind.cheongyeonbe.global.properties.S3Properties;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,8 +45,10 @@ import java.util.stream.Collectors;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Slf4j
 public class EraserService {
     public static final int MAX_USABLE_POINT = 20000;
+    public static final String MANAGER_PROFILE_IMG = "/backend/profile/manager.png";
 
     private final GroupMemberRepository groupMemberRepository;
     private final TaskOccurrenceRepository taskOccurrenceRepository;
@@ -346,9 +349,14 @@ public class EraserService {
     public List<ManagerCallResponse> getManagerCalls(Long groupId, LocalDate date) {
         List<ReservationItem> items = reservationItemRepository.findByGroupIdAndDate(groupId, date);
 
+        String fullImgUrl = Optional.ofNullable(s3Properties.getBaseUrl())
+                .map(base -> base + MANAGER_PROFILE_IMG)
+                .orElseThrow(() -> new BusinessException(ErrorCode.S3_CONFIG_ERROR));
+
         return items.stream()
                 .map(item -> ManagerCallResponse.builder()
                         .reservationItemId(item.getReservationItemId())
+                        .imgUrl(fullImgUrl)
                         .serviceName(item.getTaskTitle())
                         .visitTime(item.getVisitTime())
                         .point(item.getRewardPoint())


### PR DESCRIPTION
- Closes #154 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 매니저 호출 응답에 매니저 프로필 이미지 URL이 추가되어 더 완전한 사용자 정보를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->