### PR TITLE
[Fix] 협약서 작성 시 멤버 수 제약 조건 변경

### DIFF
--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/agreement/service/AgreementService.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/agreement/service/AgreementService.java
@@ -52,7 +52,7 @@ public class AgreementService {
         // 2. 멤버 수 확인 (2~100명, 시연용으로 확장)
         List<GroupMember> activeMembers = groupMemberRepository.findByGroup_GroupIdAndStatusNot(
                 group.getGroupId(), MemberStatus.LEFT);
-        if (activeMembers.size() <= 1 || activeMembers.size() > 100) {
+        if (activeMembers.size() > 100) {
             throw new IllegalArgumentException("그룹 멤버 수는 1~100명이어야 합니다. 현재: " + activeMembers.size() + "명");
         }
 


### PR DESCRIPTION
- Closes #161 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 계약 생성 시 멤버 수 검증이 개선되었습니다. 1명 이하의 그룹도 이제 계약 생성이 가능합니다. 100명을 초과하는 그룹은 여전히 거부됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->