### PR TITLE
[Fix] 모든 멤버 서명 확인 및 최소 인원 검증 로직을 추가하여 협약서 동의 없이 오너가 협약서 작성 완료하는 버그 해결

### DIFF
--- a/src/main/java/com/catchsolmind/cheongyeonbe/domain/agreement/service/AgreementService.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/domain/agreement/service/AgreementService.java
@@ -12,6 +12,8 @@ import com.catchsolmind.cheongyeonbe.domain.agreement.repository.AgreementSignRe
 import com.catchsolmind.cheongyeonbe.domain.group.entity.Group;
 import com.catchsolmind.cheongyeonbe.domain.group.entity.GroupMember;
 import com.catchsolmind.cheongyeonbe.domain.group.repository.GroupMemberRepository;
+import com.catchsolmind.cheongyeonbe.global.BusinessException;
+import com.catchsolmind.cheongyeonbe.global.ErrorCode;
 import com.catchsolmind.cheongyeonbe.global.enums.AgreementStatus;
 import com.catchsolmind.cheongyeonbe.global.enums.MemberRole;
 import com.catchsolmind.cheongyeonbe.global.enums.MemberStatus;
@@ -282,10 +284,16 @@ public class AgreementService {
             throw new IllegalArgumentException("이미 확정된 협약서입니다.");
         }
 
-        // 4. 모든 멤버 서명 확인
+        // 4. 모든 멤버 서명 확인 및 최소 인원 검증
         List<GroupMember> activeMembers = groupMemberRepository.findByGroup_GroupIdAndStatusNot(
                 group.getGroupId(), MemberStatus.LEFT);
+
+        if (activeMembers.size() < 2) {
+            throw new BusinessException(ErrorCode.NOT_ENOUGH_GROUP_MEMBERS);
+        }
+
         long signedCount = agreementSignRepository.countByAgreement_AgreementId(agreementId);
+
         if (signedCount != activeMembers.size()) {
             throw new IllegalArgumentException("모든 멤버가 서명해야 확정할 수 있습니다. (서명: " + signedCount + "/" + activeMembers.size() + ")");
         }

--- a/src/main/java/com/catchsolmind/cheongyeonbe/global/ErrorCode.java
+++ b/src/main/java/com/catchsolmind/cheongyeonbe/global/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
     // Group
     GROUP_NOT_FOUND("GROUP001", "그룹을 찾을 수 없습니다."),
     NOT_SAME_GROUP("GROUP002", "같은 그룹이 아닙니다."),
+    NOT_ENOUGH_GROUP_MEMBERS("GROUP003", "협약서 확정을 위해 최소 2명 이상의 멤버가 필요합니다."),
 
     // Member
     MEMBER_NOT_FOUND("MEMBER001", "멤버를 찾을 수 없습니다."),


### PR DESCRIPTION
- Closes #181 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 기능 개선

* 협약서 확정 전에 그룹의 활성 멤버가 최소 2명 이상임을 확인하는 검증 기능이 추가되었습니다. 검증 조건을 충족하지 않을 경우 사용자는 명확한 오류 메시지를 받고 협약서 확정이 중단됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->